### PR TITLE
docs: fix logo path

### DIFF
--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -2,8 +2,8 @@
   "title": "Nuxt Cloudinary",
   "url": "https://cloudinary.nuxtjs.org",
   "logo": {
-    "light": "logo-light.svg",
-    "dark": "logo-dark.svg"
+    "light": "/logo-light.svg",
+    "dark": "/logo-dark.svg"
   },
   "github": "nuxt-community/cloudinary-module",
   "twitter": "mayashavin",


### PR DESCRIPTION
On nested pages, the logo path is incorrect.

Page : https://cloudinary.nuxtjs.org/usage/build-urls-and-tags
Logo path: https://cloudinary.nuxtjs.org/usage/build-urls-and-tags/logo-light.svg

Correct configuration on nuxt/content:
https://github.com/nuxt/content/blob/dev/docs/content/settings.json