### PR TITLE
docs: fix GitHub edit link

### DIFF
--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -6,6 +6,5 @@
     "dark": "logo-dark.svg"
   },
   "github": "nuxt-community/cloudinary-module",
-  "twitter": "mayashavin",
-  "defaultBranch": "dev"
+  "twitter": "mayashavin"
 }


### PR DESCRIPTION
The default branch is `master`, `@nuxt/content-theme-docs` can detect it automatically :
https://content.nuxtjs.org/themes/docs#properties

> The default branch for the GitHub repository of your project, used in the Edit this page on GitHub link on each page (defaults to main if it cannot be detected).