### PR TITLE
Allow Client-Side Signed Uploads

### DIFF
--- a/docs/content/en/usage/upload.md
+++ b/docs/content/en/usage/upload.md
@@ -1,6 +1,6 @@
 ---
 title: Upload Media Assets
-description: 'How to upload assets to Cloudinary'
+description: "How to upload assets to Cloudinary"
 position: 7
 category: Usage
 categoryPosition: 2
@@ -14,17 +14,17 @@ To upload an media asset, you can use `this.$cloudinary.upload` (within a compon
 
 <badge>v1.0.0+</badge>
 
-* `file`
-  * Type: `String`
-  * `required`
-  * Path to the target asset file for uploading
-* `options`
-  * Type: `Object`
-  * Configuration options to apply to the target asset during uploading to Cloudinary.
-* `callback`
-  * Type: `Function`
-  * A callback method to trigger once the upload is completed. It is **not** needed if you are using ES6 `async/await` or Promise API.
-* Returns a `Promise<Asset | Error>`
+- `file`
+  - Type: `String`
+  - `required`
+  - Path to the target asset file for uploading
+- `options`
+  - Type: `Object`
+  - Configuration options to apply to the target asset during uploading to Cloudinary.
+- `callback`
+  - Type: `Function`
+  - A callback method to trigger once the upload is completed. It is **not** needed if you are using ES6 `async/await` or Promise API.
+- Returns a `Promise<Asset | Error>`
 
 <alert type="info">
 
@@ -52,11 +52,10 @@ Once resolved sucessfully, the method returns an [Asset](#asset) containing info
 
 ```js
 /* Upload to folder `content` and rename the asset to `Example` */
-const instance = this.$cloudinary
-                .upload('m-target-file-path', {
-                  public_id: 'Example',
-                  folder: 'content'
-                })
+const instance = this.$cloudinary.upload("m-target-file-path", {
+  public_id: "Example",
+  folder: "content",
+});
 ```
 
 <alert type="info">
@@ -85,46 +84,98 @@ It's **required** to provide `options.upload_preset` per call. Check out [Upload
 
 Client-side `upload` receives `options` parameter with the following properties:
 
-* `upload_preset`
-  * Type: `String`
-  * `required`
-  * **Unsigned** upload preset defined for your Cloudinary account.
-* `public_id`
-  * Type: `String`
-  * The identifier for accessing the uploaded asset.
-* `folder`
-  * Type: `String`
-  * Folder name where the uploaded asset will be store.
-* `tags`
-  * Type: `Array<String>`
-  * List of tag names to assign to the uploaded asset, such as `['animal', 'dog']`
-* `context`
-  * Type: `Array<Object>`
-  * List of key-value pairs of general textual contet metadata to attach to the uploaded asset.
-* `face_coordinates`
-  * Type: `Array<Array>`
-  * For **images only**
-  * List of array of coordinates (`[ x, y, width, height ]`) of faces contained in the uploaded asset. This is for overriding the automatically detected faces.
-* `custom_coordinates`
-  * Type: `Array<Array>`
-  * For **images only**
-  * List of array of coordinates (`[ x, y, width, height ]`) of single region contained in the uploaded asset. It is relevant only if you are planning to crop images using `custom` gravity.
+- `upload_preset`
+  - Type: `String`
+  - `required`
+  - **Unsigned** upload preset defined for your Cloudinary account.
+- `public_id`
+  - Type: `String`
+  - The identifier for accessing the uploaded asset.
+- `folder`
+  - Type: `String`
+  - Folder name where the uploaded asset will be store.
+- `tags`
+  - Type: `Array<String>`
+  - List of tag names to assign to the uploaded asset, such as `['animal', 'dog']`
+- `context`
+  - Type: `Array<Object>`
+  - List of key-value pairs of general textual contet metadata to attach to the uploaded asset.
+- `face_coordinates`
+  - Type: `Array<Array>`
+  - For **images only**
+  - List of array of coordinates (`[ x, y, width, height ]`) of faces contained in the uploaded asset. This is for overriding the automatically detected faces.
+- `custom_coordinates`
+  - Type: `Array<Array>`
+  - For **images only**
+  - List of array of coordinates (`[ x, y, width, height ]`) of single region contained in the uploaded asset. It is relevant only if you are planning to crop images using `custom` gravity.
 
 Once resolved sucessfully, the method returns an [Asset](#asset) containing information about the uploaded asset, or an `Error` otherwise.
 
 ```js
 /* Upload to folder `content` and rename the asset to `Example` */
-const instance = this.$cloudinary
-                .upload('m-target-file-path', {
-                  public_id: 'Example',
-                  folder: 'content',
-                  upload_preset: 'example_preset'
-                })
+const instance = this.$cloudinary.upload("m-target-file-path", {
+  public_id: "Example",
+  folder: "content",
+  upload_preset: "example_preset",
+});
 ```
 
 <alert type="warning">
 
 Client-side upload using unsigned upload preset is **not** secured, since the upload preset is exposed and can be used with a different account to have resources uploaded to the original account **without approval**.
+
+</alert>
+
+### Client-side Upload (Pre-signed)
+
+<badge>v1.0.0+</badge>
+
+It's possible to secure client-side uploads by generating a signature beforehand, that we pass to the upload request. These uploads _do not_ require you to pass an [upload preset](#upload-preset), but you may still include one if you are using signed upload presets.
+
+<alert type="warning">
+
+Generating a signature requires a server-side environment. This could be done in your own API, or by using a serverless function. See the Cloudinary documentation on [generating authentication signatures](https://cloudinary.com/documentation/upload_images#generating_authentication_signatures) for more details.
+
+</alert>
+
+To generate a valid signature, at the bare minimum you need to pass a unix timestamp. If successful, the signature you receive will be valid for ** 1 hour** after you generated it.
+
+If you plan on passing any additional parameters to your upload (such as `public_id`, `tags`, etc.), you _must_ include them in the signature request.
+
+<alert type="info">
+
+When generating a signature, you do _not_ need to include the `file`, `cloud_name`, `resource_type`, or `api_key` parameters.
+
+</alert>
+
+Once you have successfully generated a signature, you need to pass that signature, along with the timestamp and your Cloudinary API key to the upload request.
+
+```js
+/* An example of sending a request to an API to generate
+a signature, and then performing an upload */
+const options = {
+  timestamp: Date.now(),
+  public_id: "media/cat.png",
+  tags: ["animal", "cat"],
+};
+
+const signature = await this.$axios.$post(
+  "/api/generate-cloudinary-signature",
+  options
+);
+
+if (signature) {
+  const asset = await this.$cloudinary.upload("m-target-file-path", {
+    ...options,
+    signature,
+    api_key: this.$config.cloudinaryApiKey,
+  });
+}
+```
+
+<alert type="warning">
+
+Note that this **will** expose your Cloudinary API key to the public. Since we are only passing our API **key**, and not our API **secret**, this is generally considered safe, but something to be aware of nonetheless.
 
 </alert>
 
@@ -154,48 +205,48 @@ This is the **read-only** object containing an asset's information, which is ret
 
 Below are some main properties:
 
-* `public_id`
-  * Type: `String`
-  * The asset's public identifier (path to the asset stored in Cloudinary)
-* `asset_id`
-  * Type: `String`
-  * Asset's hashed id
-* `format`
-  * Type: `String`
-  * Original format, such as `.png`, `.jpg`, etc.
-* `secure_url`
-  * Type: `String`
-  * Original delivery URL using HTTPS
-* `url`
-  * Type: `String`
-  * Original unsecured delivery URL (HTTP)
-* `type`
-  * Type: `String`
-  * Asset's delivery type, can be `fetch`, `upload`, `authenticated`, `private`, etc.
-* `version`
-  * Type: `String`
-  * Current version of the asset
-* `height`
-  * Type: `Number`
-  * Asset's height
-* `width`
-  * Type: `Number`
-  * Asset's width
-* `eager`
-  * Type: `Array<Object>`
-  * Pre-generate assets' info based on the eager transformations passed
-* `placeholder`
-  * Type: `Boolean`
-  * Whether there is a placeholder generated
-* `tags`
-  * Type: `Array`
-  * All the tags assigned to the asset
-* `original_filename`
-  * Type: `String`
-  * The original filename when uploading
-* `overwritten`
-  * Type: `Boolean`
-  * Whether it is overwritten (**for upload**)
+- `public_id`
+  - Type: `String`
+  - The asset's public identifier (path to the asset stored in Cloudinary)
+- `asset_id`
+  - Type: `String`
+  - Asset's hashed id
+- `format`
+  - Type: `String`
+  - Original format, such as `.png`, `.jpg`, etc.
+- `secure_url`
+  - Type: `String`
+  - Original delivery URL using HTTPS
+- `url`
+  - Type: `String`
+  - Original unsecured delivery URL (HTTP)
+- `type`
+  - Type: `String`
+  - Asset's delivery type, can be `fetch`, `upload`, `authenticated`, `private`, etc.
+- `version`
+  - Type: `String`
+  - Current version of the asset
+- `height`
+  - Type: `Number`
+  - Asset's height
+- `width`
+  - Type: `Number`
+  - Asset's width
+- `eager`
+  - Type: `Array<Object>`
+  - Pre-generate assets' info based on the eager transformations passed
+- `placeholder`
+  - Type: `Boolean`
+  - Whether there is a placeholder generated
+- `tags`
+  - Type: `Array`
+  - All the tags assigned to the asset
+- `original_filename`
+  - Type: `String`
+  - The original filename when uploading
+- `overwritten`
+  - Type: `Boolean`
+  - Whether it is overwritten (**for upload**)
 
 Example of a returned asset:
 
@@ -208,10 +259,10 @@ Example of a returned asset:
  format: 'jpg',
  created_at: '2017-08-10T09:55:32Z',
  resource_type: 'image',
- tags: [], 
- bytes: 9597, 
- type: 'upload', 
- etag: 'd1ac0ee70a9a36b14887aca7f7211737', 
+ tags: [],
+ bytes: 9597,
+ type: 'upload',
+ etag: 'd1ac0ee70a9a36b14887aca7f7211737',
  url: 'http://res.cloudinary.com/demo/image/upload/v1312461204/sample.jpg',
  secure_url: 'https://res.cloudinary.com/demo/image/upload/v1312461204/sample.jpg',
  signature: 'abcdefgc024acceb1c1baa8dca46717137fa5ae0c3',

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -27,10 +27,10 @@ class ClientApi extends CloudinaryApi {
   upload(file, options, callback) {
     if (!(options.upload_preset || options.signature)) {
       throw new Error('To perform unsigned client-side uploads to Cloudinary, you need to create an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
-    } else {
-      if (options.signature && !(options.api_key && options.timestamp)) {
-        throw new Error('Signed uploads require your Cloudinary API key, and a timestamp matching the one you used to generate the signature 👉: https://cloudinary.com/documentation/upload_images#generating_authentication_signatures')
-      }
+    }
+
+    if (options.signature && !(options.api_key && options.timestamp)) {
+      throw new Error('Signed uploads require your Cloudinary API key, and a timestamp matching the one you used to generate the signature 👉: https://cloudinary.com/documentation/upload_images#generating_authentication_signatures')
     }
 
     const endpoint = `https://api.cloudinary.com/v1_1/${this._configurations.cloud_name}/upload`

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -36,7 +36,6 @@ class ClientApi extends CloudinaryApi {
     }
 
     const endpoint = `https://api.cloudinary.com/v1_1/${this._configurations.cloud_name}/upload`
-    console.log(this._configurations)
 
     const request = fetch(endpoint, {
       method: 'POST',

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -28,10 +28,8 @@ class ClientApi extends CloudinaryApi {
     if (!(options.upload_preset || options.signature)) {
       throw new Error('To perform unsigned client-side uploads to Cloudinary, you need to create an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
     } else {
-      if (options.signature) {
-        if (!(options.api_key && options.timestamp)) {
-          throw new Error('Signed uploads require your Cloudinary API key, and a timestamp matching the one you used to generate the signature 👉: https://cloudinary.com/documentation/upload_images#generating_authentication_signatures')
-        }
+      if (options.signature && !(options.api_key && options.timestamp)) {
+        throw new Error('Signed uploads require your Cloudinary API key, and a timestamp matching the one you used to generate the signature 👉: https://cloudinary.com/documentation/upload_images#generating_authentication_signatures')
       }
     }
 

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -26,7 +26,7 @@ class ClientApi extends CloudinaryApi {
   }
   upload(file, options, callback) {
     if (!(options.upload_preset || options.signature)) {
-      throw new Error('To perform client-side uploads to Cloudinary, you need to create an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
+      throw new Error('To perform unsigned client-side uploads to Cloudinary, you need to create an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
     } else {
       if (options.signature) {
         if (!(options.api_key && options.timestamp)) {

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -25,11 +25,18 @@ class ClientApi extends CloudinaryApi {
     super(config)
   }
   upload(file, options, callback) {
-    if (!options.upload_preset) {
-      throw new Error('To use upload to Cloudinary on client side, you need to set up upload preset 👉: https://cloudinary.com/documentation/upload_presets')
+    if (!(options.upload_preset || options.signature)) {
+      throw new Error('To upload files to Cloudinary on the client side, you need to set up an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
+    } else {
+      if (options.signature) {
+        if (!(options.api_key && options.timestamp)) {
+          throw new Error('Signed uploads require your Cloudinary API key, and a timestamp matching the one you used to generate the signature 👉: https://cloudinary.com/documentation/upload_images#generating_authentication_signatures')
+        }
+      }
     }
-  
+
     const endpoint = `https://api.cloudinary.com/v1_1/${this._configurations.cloud_name}/upload`
+    console.log(this._configurations)
 
     const request = fetch(endpoint, {
       method: 'POST',

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -26,7 +26,7 @@ class ClientApi extends CloudinaryApi {
   }
   upload(file, options, callback) {
     if (!(options.upload_preset || options.signature)) {
-      throw new Error('To upload files to Cloudinary on the client side, you need to set up an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
+      throw new Error('To perform client-side uploads to Cloudinary, you need to create an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
     } else {
       if (options.signature) {
         if (!(options.api_key && options.timestamp)) {


### PR DESCRIPTION
It's possible to perform a client-side upload without passing an upload preset if the user generates a [signed upload](https://cloudinary.com/documentation/upload_images#generating_authentication_signatures). 

This PR updates the check for an upload preset on the client, and instead looks for an upload preset _or_ a signature in the upload options. If a signature is included, it ensures that a timestamp and API key are included in the upload options as well, as these are both required to perform a signed upload.

I also made some small grammatical tweaks to the upload preset error message, I hope that's ok!