### PR TITLE
fix: #31 api_key of undefine and snakecase convert

### DIFF
--- a/lib/templates/cloudinary-api.js
+++ b/lib/templates/cloudinary-api.js
@@ -46,9 +46,9 @@ const DELIVERY_TYPES = {
 
 class CloudinaryApi {
   constructor(configurations) {
-    this._configurations = configurations
+    this._configurations = sdk.Util.withSnakeCaseKeys(configurations)
 
-    const cld = new sdk.Cloudinary(configurations)
+    const cld = new sdk.Cloudinary(this._configurations)
 
     this.image = {
       /**
@@ -122,7 +122,7 @@ class CloudinaryApi {
   config(options = {}) {
     const updatedInstance = new CloudinaryApi({
       ...this._configurations,
-      ...options
+      ...sdk.Util.withSnakeCaseKeys(options)
     })
 
     return updatedInstance
@@ -134,9 +134,11 @@ class CloudinaryApi {
    * @param {Function} callback - callback handler (optional)
    * @returns {Promise<Asset> | Promise<{ msg: {String} }>}
    */
-  upload(file, options, callback) {
-    if (!options.api_key && !this._configurations.api_key
-      && !options.api_secret && !this._configurations.api_secret) {
+  upload(file, options = {}, callback) {
+    const $options = sdk.Util.withSnakeCaseKeys(options)
+
+    if (!$options.api_key && !this._configurations.api_key
+      && !$options.api_secret && !this._configurations.api_secret) {
       throw new Error('API Key and Secret Key are needed for upload API')
     }
 
@@ -146,7 +148,7 @@ class CloudinaryApi {
 
     const uploader = cldServer.uploader
 
-    return uploader.upload(file, options, callback)
+    return uploader.upload(file, $options, callback)
   }
   /**
    * 
@@ -154,9 +156,11 @@ class CloudinaryApi {
    * @param {{ type: {DeliveryType} }} options - options to apply on the asset : https://cloudinary.com/documentation/image_upload_api_reference#optional_parameters-6
    * @returns {Asset | null} 
    */
-  async explicit(publicId, options) {
-    if (!options.api_key && !this._configurations.api_key
-      && !options.api_secret && !this._configurations.api_secret) {
+  async explicit(publicId, options = {}) {
+    const $options = sdk.Util.withSnakeCaseKeys(options)
+
+    if (!$options.api_key && !this._configurations.api_key
+      && !$options.api_secret && !this._configurations.api_secret) {
       throw new Error('API Key and Secret Key are needed for explicit API')
     }
 
@@ -167,7 +171,7 @@ class CloudinaryApi {
     const uploader = cldServer.uploader
 
     try {
-      const asset = await uploader.explicit(publicId, options)
+      const asset = await uploader.explicit(publicId, $options)
 
       return asset
     } catch (error) {
@@ -179,3 +183,5 @@ class CloudinaryApi {
 module.exports = CloudinaryApi
 
 module.exports.DELIVERY_TYPES = DELIVERY_TYPES
+
+module.exports.withSnakeCaseKeys = sdk.Util.withSnakeCaseKeys

--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import Cloudinary from 'cloudinary-vue'
-import CloudinaryApi from './cloudinary-api'
+import CloudinaryApi, { withSnakeCaseKeys } from './cloudinary-api'
 
 const configuration = {
   cloudName: '<%= options.cloudName %>',
@@ -24,12 +24,14 @@ class ClientApi extends CloudinaryApi {
   constructor(config) {
     super(config)
   }
-  upload(file, options, callback) {
-    if (!(options.upload_preset || options.signature)) {
+  upload(file, options = {}, callback) {
+    const $options = withSnakeCaseKeys(options)
+
+    if (!($options.upload_preset || $options.signature)) {
       throw new Error('To perform unsigned client-side uploads to Cloudinary, you need to create an upload preset 👉: https://cloudinary.com/documentation/upload_presets')
     }
 
-    if (options.signature && !(options.api_key && options.timestamp)) {
+    if ($options.signature && !($options.api_key && $options.timestamp)) {
       throw new Error('Signed uploads require your Cloudinary API key, and a timestamp matching the one you used to generate the signature 👉: https://cloudinary.com/documentation/upload_images#generating_authentication_signatures')
     }
 
@@ -41,7 +43,7 @@ class ClientApi extends CloudinaryApi {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        ...options,
+        ...$options,
         file: file,
       })
     }).then(res => res.json())


### PR DESCRIPTION
Fixes:
1. `options` passed to `upload` should fallback to default `{}` if nothing passed.
2. Support writing in camelCase for setting up new configs (`api_key` or `apiKey` are acceptable in `upload` and `explicit`)