### PR TITLE
refer to valid component method

### DIFF
--- a/docs/content/en/examples/basic.md
+++ b/docs/content/en/examples/basic.md
@@ -173,7 +173,7 @@ export default {
   },
   computed: {
     src() {
-      return this.url(
+      return this.fetchRemote(
         this.url,
         {
           gravity: 'auto:subject',


### PR DESCRIPTION
Refer to `fetchRemote()` component method instead of non-existent `url()` method